### PR TITLE
Implement batch producer for node client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
   check_fmt:
-    name: check formatting
+    name: Check fmt and clippy
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         rust: [stable]
         node: [ '14' ]
     steps:
@@ -31,16 +31,17 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: clippy
-      - name: check fmt
+      - name: Check fmt
         run: cargo fmt -- --check
-      - name: check clippy
-        run: cargo clippy -- -D warnings
+      - name: Check clippy
+        run: make check-clippy
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - name: check prettier
+      - name: Check prettier
         run: make npm_lint
+
   smoke_test:
     name: Smoke test
     runs-on: ${{ matrix.os }}
@@ -89,6 +90,7 @@ jobs:
       - name: Run Examples
         run: |
           FLUVIO_DEV=1 make examples
+
   check_security:
     name: check security
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [stable]
         node: [ '14' ]
     steps:
       - uses: actions/checkout@v2
-      - name: Install ${{ matrix.rust }}
+      - name: Install Rust stable
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           override: true
           components: clippy
       - name: Check fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ### Improvements
 ### Fixed
 
+## 0.7.2
+
+### Improvements
+
+- Add `sendAll` method for producing batches of records at once
+
 ## 0.6
 
 ### Improvements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "nj-core"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "async-trait",
  "ctor",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "nj-derive"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,8 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.6.0"
+version = "0.6.1-alpha.1"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "async-channel",
  "async-mutex",
@@ -496,6 +497,7 @@ dependencies = [
 [[package]]
 name = "fluvio-controlplane-metadata"
 version = "0.7.0"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "async-trait",
  "fluvio-dataplane-protocol",
@@ -512,6 +514,7 @@ dependencies = [
 [[package]]
 name = "fluvio-dataplane-protocol"
 version = "0.4.1"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -572,6 +575,7 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol"
 version = "0.4.1"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "bytes",
  "fluvio-future 0.2.0",
@@ -585,6 +589,7 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol-api"
 version = "0.3.0"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "fluvio-protocol-core",
  "fluvio-protocol-derive",
@@ -595,6 +600,7 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol-codec"
 version = "0.3.0"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "bytes",
  "fluvio-protocol-core",
@@ -605,6 +611,7 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol-core"
 version = "0.3.0"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "bytes",
  "log",
@@ -613,6 +620,7 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol-derive"
 version = "0.2.0"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "log",
  "proc-macro2",
@@ -623,6 +631,7 @@ dependencies = [
 [[package]]
 name = "fluvio-sc-schema"
 version = "0.7.0"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
@@ -638,6 +647,7 @@ dependencies = [
 [[package]]
 name = "fluvio-socket"
 version = "0.7.0"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "async-channel",
  "async-mutex",
@@ -662,6 +672,7 @@ dependencies = [
 [[package]]
 name = "fluvio-spu-schema"
 version = "0.5.0"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "bytes",
  "fluvio-dataplane-protocol",
@@ -675,6 +686,7 @@ dependencies = [
 [[package]]
 name = "fluvio-stream-model"
 version = "0.5.1"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "async-rwlock",
  "event-listener",
@@ -685,6 +697,7 @@ dependencies = [
 [[package]]
 name = "fluvio-types"
 version = "0.2.3"
+source = "git+https://github.com/infinyon/fluvio?rev=8c151f8a4ae0825c38706faa088d0940264e1bef#8c151f8a4ae0825c38706faa088d0940264e1bef"
 dependencies = [
  "event-listener",
  "tracing",
@@ -1172,6 +1185,8 @@ dependencies = [
 [[package]]
 name = "nj-build"
 version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14ea1c6a7b4dedac7ae0491c32d64439d364c28366fe2f101cd479941e814680"
 dependencies = [
  "cc",
  "reqwest",
@@ -1180,6 +1195,8 @@ dependencies = [
 [[package]]
 name = "nj-core"
 version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d6f111b66fe4cc1dd1c42f86da1fb96517d29137a3c03120c287376612417f"
 dependencies = [
  "async-trait",
  "ctor",
@@ -1196,6 +1213,8 @@ dependencies = [
 [[package]]
 name = "nj-derive"
 version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a6e0175b8004d809c74566f002f30114c79395cf842ae853410140b4f80ab9"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -1206,10 +1225,14 @@ dependencies = [
 [[package]]
 name = "nj-sys"
 version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de78f0e9f8a2a4f224273e282f9b61bfe8d598b22fe9d00a57b09e1f6b1cd51"
 
 [[package]]
 name = "node-bindgen"
 version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36d0a7428be8bf4c5402044fd24a1b0d3a1be5c89543e7457a38ca123909885"
 dependencies = [
  "nj-build",
  "nj-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,14 +439,13 @@ dependencies = [
 [[package]]
 name = "fluvio"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419bbc828fe12204f62b98839072981bd45076f04437a2a4f05786d0100dcad4"
 dependencies = [
  "async-channel",
  "async-mutex",
  "async-rwlock",
  "async-trait",
  "base64 0.13.0",
+ "bytes",
  "dirs",
  "event-listener",
  "fluvio-dataplane-protocol",
@@ -497,8 +496,6 @@ dependencies = [
 [[package]]
 name = "fluvio-controlplane-metadata"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d26e61543e331e1a6c72f9eeda22de72c710619c8b262b783a6f23b56a3f359"
 dependencies = [
  "async-trait",
  "fluvio-dataplane-protocol",
@@ -514,11 +511,10 @@ dependencies = [
 
 [[package]]
 name = "fluvio-dataplane-protocol"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdda09be3eac82d88d42e411c3536e949a8e9ab6fcdf346848fe7976f116d5a1"
+version = "0.4.1"
 dependencies = [
  "bytes",
+ "cfg-if 1.0.0",
  "content_inspector",
  "crc32c",
  "fluvio-future 0.2.0",
@@ -528,6 +524,7 @@ dependencies = [
  "log",
  "once_cell",
  "semver",
+ "tracing",
 ]
 
 [[package]]
@@ -574,9 +571,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-protocol"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5748d15d4d86ec252304ab783b391dcff39dc237f16de84fab01158ef5670535"
+version = "0.4.1"
 dependencies = [
  "bytes",
  "fluvio-future 0.2.0",
@@ -590,8 +585,6 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol-api"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae66072f907fffff49299438a9afe0379aa4718587f408eb5d98545445ff0c6c"
 dependencies = [
  "fluvio-protocol-core",
  "fluvio-protocol-derive",
@@ -602,8 +595,6 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol-codec"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429f2a2fa021a83a04bd24605e7440d8f7ef64191514737007556d0400ea2f6a"
 dependencies = [
  "bytes",
  "fluvio-protocol-core",
@@ -614,8 +605,6 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol-core"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c950608da27edf870cdebb301e64a09c8de3bda11c9b374ffa892e80bab2024a"
 dependencies = [
  "bytes",
  "log",
@@ -624,8 +613,6 @@ dependencies = [
 [[package]]
 name = "fluvio-protocol-derive"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a2bb5eeabcfffd406155caa7dfc1e75367c6dd825c769572815f6300f9c50f"
 dependencies = [
  "log",
  "proc-macro2",
@@ -636,8 +623,6 @@ dependencies = [
 [[package]]
 name = "fluvio-sc-schema"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1dea58a416db8d34d94d609d55f2646e9679b9aa0af1a9cdd2b8ac03f93f2b3"
 dependencies = [
  "fluvio-controlplane-metadata",
  "fluvio-dataplane-protocol",
@@ -653,8 +638,6 @@ dependencies = [
 [[package]]
 name = "fluvio-socket"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538cdb427ec37752e8cb9d3b0a9c1a1418ef8b6a4a0b74084ee64c1edf323fc8"
 dependencies = [
  "async-channel",
  "async-mutex",
@@ -679,8 +662,6 @@ dependencies = [
 [[package]]
 name = "fluvio-spu-schema"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e2871b9c63880d7f68cde2ca21eb5a3bf8cf6874f39975d2bbbdbaafdc28a2"
 dependencies = [
  "bytes",
  "fluvio-dataplane-protocol",
@@ -694,8 +675,6 @@ dependencies = [
 [[package]]
 name = "fluvio-stream-model"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad47fd2cd14d75ea98228f049185732a676aa1390e38d9ad858b7b12b9dd610"
 dependencies = [
  "async-rwlock",
  "event-listener",
@@ -705,9 +684,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ae978fa5451502e6065fbc717ef92a334d9281ec8179caf21fe2c7c8adf34"
+version = "0.2.3"
 dependencies = [
  "event-listener",
  "tracing",
@@ -1195,8 +1172,6 @@ dependencies = [
 [[package]]
 name = "nj-build"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ea1c6a7b4dedac7ae0491c32d64439d364c28366fe2f101cd479941e814680"
 dependencies = [
  "cc",
  "reqwest",
@@ -1205,8 +1180,6 @@ dependencies = [
 [[package]]
 name = "nj-core"
 version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4773354ebc5349a3e3dc5e1c6dac7d7182c890ef7e051a14926a51648fe74a2"
 dependencies = [
  "async-trait",
  "ctor",
@@ -1223,8 +1196,6 @@ dependencies = [
 [[package]]
 name = "nj-derive"
 version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6912edd460c342732175a256d60261206eec8f319234243321e92fefa07018e3"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -1235,14 +1206,10 @@ dependencies = [
 [[package]]
 name = "nj-sys"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de78f0e9f8a2a4f224273e282f9b61bfe8d598b22fe9d00a57b09e1f6b1cd51"
 
 [[package]]
 name = "node-bindgen"
 version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36d0a7428be8bf4c5402044fd24a1b0d3a1be5c89543e7457a38ca123909885"
 dependencies = [
  "nj-build",
  "nj-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-client-node"
-version = "4.0.0"
+version = "0.7.2"
 dependencies = [
  "fluvio",
  "fluvio-future 0.1.15",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "nj-core"
-version = "4.2.1"
+version = "4.3.0"
 dependencies = [
  "async-trait",
  "ctor",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "nj-derive"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-client-node"
-version = "4.0.0"
+version = "0.7.2"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,11 @@ log = "0.4.13"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.61"
 node-bindgen = "4.1.0"
-fluvio = { version = "0.6.0", features = ["admin"] }
+fluvio = { version = "0.6.1-alpha.1", features = ["admin"] }
 fluvio-future = { version = "0.1.15", features = ["tls", "task", "io"] }
 
 [build-dependencies]
 node-bindgen = { version = "4.3.0", features = ["build"] }
 
 [patch.crates-io]
-fluvio = { path = "../fluvio/src/client" }
-node-bindgen = { path = "../node-bindgen" }
+fluvio = { git = "https://github.com/infinyon/fluvio", rev = "8c151f8a4ae0825c38706faa088d0940264e1bef" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ fluvio-future = { version = "0.1.15", features = ["tls", "task", "io"] }
 
 [build-dependencies]
 node-bindgen = { version = "4.3.0", features = ["build"] }
+
+[patch.crates-io]
+fluvio = { path = "../fluvio/src/client" }
+node-bindgen = { path = "../node-bindgen" }

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,11 @@ example_create_managed_spu:	build
 example_delete_managed_spu:	build
 	FLUVIO_DEV=1 npx ts-node ./examples/deleteManagedSpu.ts
 
-check-clippy:
-	cargo clippy -- --all --all-features --all-targets \
+install-clippy:
+	rustup component add clippy --toolchain stable
+
+check-clippy: install-clippy
+	cargo +stable clippy --all --all-features --all-targets -- \
 		-D warnings \
+		-A clippy::needless_question_mark \
 		-A clippy::upper_case_acronyms

--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,8 @@ example_create_managed_spu:	build
 
 example_delete_managed_spu:	build
 	FLUVIO_DEV=1 npx ts-node ./examples/deleteManagedSpu.ts
+
+check-clippy:
+	cargo clippy -- --all --all-features --all-targets \
+		-D warnings \
+		-A clippy::upper_case_acronyms

--- a/examples/produceBatch.ts
+++ b/examples/produceBatch.ts
@@ -31,7 +31,7 @@ async function produce() {
         await sleep(10000)
 
         const producer = await fluvio.topicProducer(TOPIC_NAME)
-        const records: KeyValue[] = [];
+        const records: KeyValue[] = []
         for (let i: number = 1; i < 10; i++) {
             // Create a JSON message as our value
             const message = JSON.stringify({
@@ -41,9 +41,9 @@ async function produce() {
 
             const encoder = new TextEncoder()
             const key: ArrayBuffer = encoder.encode(`KEY ${i}`)
-            records.push([key, message]);
+            records.push([key, message])
         }
-        await producer.sendAll(records);
+        await producer.sendAll(records)
     } catch (ex) {
         console.log('error', ex)
     }

--- a/examples/produceBatch.ts
+++ b/examples/produceBatch.ts
@@ -1,0 +1,52 @@
+/* tslint:disable:no-console */
+import Fluvio, { KeyValue } from '../src/index'
+import { v4 as uuidV4 } from 'uuid'
+
+// Set delay for creating a topic;
+async function sleep(ms: number) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms)
+    })
+}
+
+// Set unique topic name
+const TOPIC_NAME = uuidV4()
+
+async function produce() {
+    try {
+        const fluvio = new Fluvio()
+
+        // Explicitly call `.connect()` to connect to the cluster;
+        // This allows for lazily-loading the connection, useful in
+        // situations where the fluvio client does not need to immediately
+        // connect.
+        await fluvio.connect()
+
+        // Set the admin client;
+        const admin = await fluvio.admin()
+
+        // Create the topic
+        await admin.createTopic(TOPIC_NAME)
+        console.log(`Producing on ${TOPIC_NAME} in 10 seconds`)
+        await sleep(10000)
+
+        const producer = await fluvio.topicProducer(TOPIC_NAME)
+        const records: KeyValue[] = [];
+        for (let i: number = 1; i < 10; i++) {
+            // Create a JSON message as our value
+            const message = JSON.stringify({
+                key: i,
+                message: `This is message ${i}`,
+            })
+
+            const encoder = new TextEncoder()
+            const key: ArrayBuffer = encoder.encode(`KEY ${i}`)
+            records.push([key, message]);
+        }
+        await producer.sendAll(records);
+    } catch (ex) {
+        console.log('error', ex)
+    }
+}
+
+produce()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fluvio/client",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "description": "Node.js binding for Fluvio distributed stream",
     "keywords": [
         "fluvio",

--- a/src/fluvio.test.ts
+++ b/src/fluvio.test.ts
@@ -1,17 +1,9 @@
 import Fluvio, {
-    arrayBufferToString,
     FluvioAdmin,
     OffsetFrom,
-    PartitionConsumer,
-    stringToArrayBuffer,
-    TopicProducer,
-    TopicReplicaParam,
-    PartitionSpecMetadata,
     Offset,
-    FetchablePartitionResponse,
 } from '../src/index'
 import { v4 as uuidV4 } from 'uuid'
-import { exec } from 'child_process'
 
 const topic_create_timeout = 10000
 async function sleep(ms: number) {
@@ -28,78 +20,6 @@ describe('Fluvio Admin', () => {
         expect(admin).toBeInstanceOf(FluvioAdmin)
     })
 })
-
-/*
- * These tests require a k8s cluster
- *
-describe('Custom SPU', () => {
-    let admin: FluvioAdmin
-    beforeAll(async () => {
-        const fluvio = await Fluvio.connect()
-        admin = await fluvio.admin()
-    })
-    test('Create, Seach, and Delete custom SPU', async () => {
-        expect(admin).toBeInstanceOf(FluvioAdmin)
-        const spuName = uuidV4()
-
-        const response = await admin.createCustomSpu(spuName)
-        expect(response).toBeUndefined()
-        await admin.deleteCustomSpu(spuName)
-
-        // Check to ensure the spu is no longer listed;
-        const data = await admin.listSpu()
-        const spus: any[] = JSON.parse(data)
-
-        const spu = spus.find((s: { name: string }) => {
-            return s.name === spuName
-        })
-
-        // Expect SPU to no longer exist;
-        expect(spu).toBeUndefined()
-    })
-})
-
-describe('Fluvio Topics', () => {
-    let admin: FluvioAdmin
-    const topic = uuidV4()
-    jest.setTimeout(100000) // 100 seconds
-    beforeAll(async () => {
-        const fluvio = await Fluvio.connect()
-        admin = await fluvio.admin()
-    })
-    test('Create, List, and Delete Topics!', async () => {
-        console.log(`Creating topic ${topic}`)
-        const new_topic = await admin.createTopic(topic)
-        await sleep(10000)
-        expect(new_topic).toEqual(topic)
-
-        console.log(`Listing topics`)
-        let data = await admin.listTopic()
-        let topics = JSON.parse(data)
-
-        expect(topics.length).toBeGreaterThan(0)
-
-        let this_topic = topics.find((topic: { name: string }) => {
-            return topic.name === new_topic
-        })
-
-        console.log(`Found this topic ${this_topic}`)
-        expect(this_topic).toBeDefined()
-
-        console.log(`Deleting this topic ${topic}`)
-        await admin.deleteTopic(topic)
-        await sleep(10000)
-
-        data = await admin.listTopic()
-        topics = JSON.parse(data)
-        this_topic = topics.find((t: { name: string }) => {
-            return t.name === topic
-        })
-
-        expect(this_topic).toBeUndefined()
-    })
-})
-/**/
 
 describe('Fluvio Consumer and Producer', () => {
     jest.setTimeout(10000) // 100 seconds
@@ -197,52 +117,8 @@ describe('Fluvio Consumer and Producer', () => {
             expect(msg).toEqual(`Message: ${i}`)
         }
     })
-
-    /*
-    test('Send and Consume using Stream!', async () => {
-        const producer = await fluvio.topicProducer(topic)
-        const messages: string[] = []
-
-        const MAX_COUNT = 10
-        const partition = 0
-        console.log('send records')
-        for (let i = 0; i < MAX_COUNT; i++) {
-            const msg = `Message: ${i}`
-            console.log(`sending message ${msg}`)
-            await producer.sendRecord(msg, partition)
-            messages.push(msg)
-            console.log(`sent message ${msg}`)
-        }
-        console.log('Creating consumer stream')
-        const offsetIndex = 0
-        const consumer = await fluvio.partitionConsumer(topic, partition)
-
-        const stream = await consumer.stream(
-            {
-                index: offsetIndex,
-                from: OffsetFrom.Beginning,
-            }
-        )
-
-        let counter = 0
-        console.log('STREAM CREATED')
-
-        stream.on('data', (record: string) => {
-            console.log('Ending stream: ', record)
-            expect(record).toEqual(`Message: ${counter}`)
-            counter++
-            if(record == 'Message: 9') {
-                console.log("Ending stream")
-                consumer.endStream() // This is broken
-                return
-            }
-        })
-        stream.on('error', (err: string) => {
-            console.error(err)
-        })
-    })
-    */
 })
+
 describe('Fluvio Producer and Consume using AsyncIterator', () => {
     jest.setTimeout(100000) // 100 seconds
     let admin: FluvioAdmin
@@ -304,52 +180,3 @@ describe('Fluvio Producer and Consume using AsyncIterator', () => {
         expect(counter).toEqual(MAX_COUNT)
     })
 })
-
-/*
-describe('Multiple Fluvio Instances', () => {
-    let admin1: FluvioAdmin
-    let admin2: FluvioAdmin
-    let admin3: FluvioAdmin
-    const topic1 = uuidV4()
-    const topic2 = uuidV4()
-    const topic3 = uuidV4()
-    beforeEach(async () => {
-        console.log('Getting fluvio admin instances!')
-
-        admin1 = await (await Fluvio.connect()).admin()
-        expect(admin1).toBeInstanceOf(FluvioAdmin)
-        console.log('Connected to first fluvio admin instances!')
-
-        admin2 = await (await Fluvio.connect()).admin()
-        expect(admin2).toBeInstanceOf(FluvioAdmin)
-        console.log('Connected to second fluvio admin instances!')
-
-        admin3 = await (await Fluvio.connect()).admin()
-        expect(admin3).toBeInstanceOf(FluvioAdmin)
-        console.log('Connected to third fluvio admin instances!')
-        await admin1.createTopic(topic1)
-        await admin2.createTopic(topic2)
-        await admin3.createTopic(topic3)
-        await sleep(topic_create_timeout)
-    })
-    afterEach(async () => {
-        await admin1.deleteTopic(topic1)
-        await admin2.deleteTopic(topic2)
-        await admin3.deleteTopic(topic3)
-        await sleep(topic_create_timeout)
-    })
-    test('Three admins create three different topics', async () => {
-        ;[topic1, topic2, topic3].forEach(async (topic) => {
-            let data = await admin1.listTopic()
-            let topics = JSON.parse(data)
-            console.log(`Looking for topic ${topic}`)
-            console.log(`Current topics: ${data}`)
-            let this_topic = topics.find((t: { name: string }) => {
-                return t.name === topic
-            })
-            console.log(`Found this topic ${this_topic}`)
-            expect(this_topic).toBeDefined()
-        })
-    })
-})
-*/

--- a/src/fluvio.test.ts
+++ b/src/fluvio.test.ts
@@ -1,9 +1,4 @@
-import Fluvio, {
-    FluvioAdmin,
-    OffsetFrom,
-    KeyValue,
-    Offset,
-} from '../src/index'
+import Fluvio, { FluvioAdmin, OffsetFrom, KeyValue, Offset } from '../src/index'
 import { v4 as uuidV4 } from 'uuid'
 
 const topic_create_timeout = 10000
@@ -206,22 +201,22 @@ describe('Fluvio Batch Producer', () => {
     test('Send records using batch producer', async () => {
         const producer = await fluvio.topicProducer(topic)
 
-        const MAX_COUNT = 10;
-        const records: KeyValue[] = [];
+        const MAX_COUNT = 10
+        const records: KeyValue[] = []
         for (let i = 0; i < MAX_COUNT; i++) {
-            const key = `${i}`;
-            const value = `This is record ${i}`;
-            const record: KeyValue = [key, value];
-            records.push(record);
+            const key = `${i}`
+            const value = `This is record ${i}`
+            const record: KeyValue = [key, value]
+            records.push(record)
         }
-        await producer.sendAll(records);
-        const consumer = await fluvio.partitionConsumer(topic, 0);
-        let counter = 0;
+        await producer.sendAll(records)
+        const consumer = await fluvio.partitionConsumer(topic, 0)
+        let counter = 0
         const stream = await consumer.createStream(Offset.FromBeginning())
         for await (const record of stream) {
-            expect(record.valueString()).toEqual(`This is record ${counter}`);
-            counter++;
-            if (counter >= MAX_COUNT) break;
+            expect(record.valueString()).toEqual(`This is record ${counter}`)
+            counter++
+            if (counter >= MAX_COUNT) break
         }
         expect(counter).toEqual(MAX_COUNT)
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,18 +108,18 @@ export interface Record {
 }
 
 /**
- * An item that may be sent via the Producer.
+ * An item that may be sent via the Producer is a string or byte buffer.
  */
-export type Item = string | ArrayBuffer
+type ProducerItem = string | ArrayBuffer
 
 /**
  * A key/value element that may be sent via the Producer.
  */
-export type KeyValue = [Item, Item]
+export type KeyValue = [ProducerItem, ProducerItem]
 
 export interface TopicProducer {
     sendRecord(data: string, partition: number): Promise<void>
-    send(key: Item, value: Item): Promise<void>
+    send(key: ProducerItem, value: ProducerItem): Promise<void>
     sendAll(records: KeyValue[]): Promise<void>
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,9 +107,20 @@ export interface Record {
     valueString(): string
 }
 
+/**
+ * An item that may be sent via the Producer.
+ */
+export type Item = string | ArrayBuffer;
+
+/**
+ * A key/value element that may be sent via the Producer.
+ */
+export type KeyValue = [Item, Item];
+
 export interface TopicProducer {
     sendRecord(data: string, partition: number): Promise<void>
-    send(key: string | ArrayBuffer, value: string | ArrayBuffer): Promise<void>
+    send(key: Item, value: Item): Promise<void>
+    sendAll(records: KeyValue[]): Promise<void>
 }
 
 /**
@@ -201,17 +212,18 @@ export class TopicProducer {
     }
 
     /**
-     * Sends a list of key-value events to this producer's topic
+     * Sends a list of key-value elements to this producer's topic
      * @param elements
      */
-    async sendAll(
-        elements: element[],
-    ): Promise<void> {
-        return
+    async sendAll(elements: KeyValue[]): Promise<void> {
+        try {
+            await this.inner.sendAll(elements)
+            return
+        } catch (error) {
+            throw new Error(`failed to send batch of key-value records due to: ${error}`)
+        }
     }
 }
-
-type element = [string | ArrayBuffer | null, string | ArrayBuffer];
 
 export interface PartitionConsumer {
     fetch(offset?: Offset): Promise<FetchablePartitionResponse>

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,12 +203,7 @@ export class TopicProducer {
         key: string | ArrayBuffer,
         value: string | ArrayBuffer
     ): Promise<void> {
-        try {
-            await this.inner.send(key, value)
-            return
-        } catch (error) {
-            throw new Error(`failed to send key-value record due to: ${error}`)
-        }
+        await this.inner.send(key, value)
     }
 
     /**
@@ -216,14 +211,7 @@ export class TopicProducer {
      * @param elements
      */
     async sendAll(elements: KeyValue[]): Promise<void> {
-        try {
-            await this.inner.sendAll(elements)
-            return
-        } catch (error) {
-            throw new Error(
-                `failed to send batch of key-value records due to: ${error}`
-            )
-        }
+        await this.inner.sendAll(elements)
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ export class TopicProducer {
     }
 
     /**
-     * Sends a key-value event to a specific partition within this producer's topic
+     * Sends a key-value event to this producer's topic
      * @param key The Key data of the record to send
      * @param value The Value data of the record to send
      */
@@ -199,7 +199,19 @@ export class TopicProducer {
             throw new Error(`failed to send key-value record due to: ${error}`)
         }
     }
+
+    /**
+     * Sends a list of key-value events to this producer's topic
+     * @param elements
+     */
+    async sendAll(
+        elements: element[],
+    ): Promise<void> {
+        return
+    }
 }
+
+type element = [string | ArrayBuffer | null, string | ArrayBuffer];
 
 export interface PartitionConsumer {
     fetch(offset?: Offset): Promise<FetchablePartitionResponse>

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,12 +110,12 @@ export interface Record {
 /**
  * An item that may be sent via the Producer.
  */
-export type Item = string | ArrayBuffer;
+export type Item = string | ArrayBuffer
 
 /**
  * A key/value element that may be sent via the Producer.
  */
-export type KeyValue = [Item, Item];
+export type KeyValue = [Item, Item]
 
 export interface TopicProducer {
     sendRecord(data: string, partition: number): Promise<void>
@@ -220,7 +220,9 @@ export class TopicProducer {
             await this.inner.sendAll(elements)
             return
         } catch (error) {
-            throw new Error(`failed to send batch of key-value records due to: ${error}`)
+            throw new Error(
+                `failed to send batch of key-value records due to: ${error}`
+            )
         }
     }
 }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -76,6 +76,30 @@ impl TopicProducerJS {
         client.send(key, value).await?;
         Ok(())
     }
+
+    #[node_bindgen]
+    async fn send_all(&self, elements: Vec<(ProduceArg, ProduceArg)>) -> Result<(), FluvioError> {
+        let client = self
+            .inner
+            .as_ref()
+            .ok_or_else(|| FluvioError::Other(CLIENT_NOT_FOUND_ERROR_MSG.to_string()))?;
+
+        let records = elements.iter().map(|(key, value)| {
+            let key = match &key {
+                ProduceArg::String(string) => string.as_bytes(),
+                ProduceArg::ArrayBuffer(buffer) => buffer.as_bytes(),
+            };
+
+            let value = match &value {
+                ProduceArg::String(string) => string.as_bytes(),
+                ProduceArg::ArrayBuffer(buffer) => buffer.as_bytes(),
+            };
+
+            (Some(key), value)
+        });
+        client.send_all(records).await?;
+        Ok(())
+    }
 }
 
 /// Callers may give 'string' or 'ArrayBuffer' values to `producer.send`

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -84,19 +84,22 @@ impl TopicProducerJS {
             .as_ref()
             .ok_or_else(|| FluvioError::Other(CLIENT_NOT_FOUND_ERROR_MSG.to_string()))?;
 
-        let records = elements.iter().map(|(key, value)| {
-            let key = match &key {
-                ProduceArg::String(string) => string.as_bytes(),
-                ProduceArg::ArrayBuffer(buffer) => buffer.as_bytes(),
-            };
+        let records: Vec<_> = elements
+            .iter()
+            .map(|(key, value)| {
+                let key = match &key {
+                    ProduceArg::String(string) => string.as_bytes(),
+                    ProduceArg::ArrayBuffer(buffer) => buffer.as_bytes(),
+                };
 
-            let value = match &value {
-                ProduceArg::String(string) => string.as_bytes(),
-                ProduceArg::ArrayBuffer(buffer) => buffer.as_bytes(),
-            };
+                let value = match &value {
+                    ProduceArg::String(string) => string.as_bytes(),
+                    ProduceArg::ArrayBuffer(buffer) => buffer.as_bytes(),
+                };
 
-            (Some(key), value)
-        });
+                (Some(key), value)
+            })
+            .collect();
         client.send_all(records).await?;
         Ok(())
     }


### PR DESCRIPTION
Subtask of https://github.com/infinyon/fluvio/issues/847

This adds the following function and types to the node client:

```typescript
type Item = string | ArrayBuffer;
type KeyValue = [Item, Item]; // Key-value tuple

async sendAll(elements: KeyValue[]): Promise<void>
```

This depends on the new tuple feature of node-bindgen, so CI will not pass until we merge that.