### PR TITLE
fix(ci): use new `--start` argument for offset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           fluvio topic create "foobar"
           sleep 3
           echo foo | fluvio produce "foobar"
-          fluvio consume foobar -o 0 -d
+          fluvio consume foobar --start 0 -d
       - name: Create Topic
         run: |
           fluvio topic create -p 1 -r 1 my-topic


### PR DESCRIPTION
Uses `--start` over `-o` for setting consumer offset on CI tests.

---

Currently when running Smoke tests the CI workflow fails due to the specification
of a deprecated argument.

Here is an example: https://github.com/infinyon/fluvio-client-node/actions/runs/3518395317/jobs/5897260836#step:4:1

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/34756077/203180277-b8976f2a-3ad6-4027-9072-4f977f65fb73.png">
