### PR TITLE
[Merged by Bors] - ci: Try older version of node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - trying
       - try-older-version-of-node-18
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   cancel_previous_runs:
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [ '16' ]
+        node: ["16"]
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust stable
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os: [macos-latest]
         rust: [stable]
-        node: [ '14', '16', '18.12' ]
+        node: ["14", "16", "18.6"]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.rust }}
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        node: [ '14', '16', '18']
+        node: ["14", "16", "18.6"]
     steps:
       - uses: AbsaOSS/k3d-action@v2
         name: "Create fluvio k3d Cluster"
@@ -94,7 +94,7 @@ jobs:
         uses: infinyon/fluvio@master
         with:
           cluster-type: local
-          version: 'latest'
+          version: "stable"
       - name: Check Fluvio Installation
         run: |
           fluvio version
@@ -138,7 +138,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        node: [ '16' ]
+        node: ["16"]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.rust }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os: [macos-latest]
         rust: [stable]
-        node: ["14", "16", "18.14.2"]
+        node: ["14", "16", "18.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.rust }}
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        node: ["14", "16", "18.14.2"]
+        node: ["14", "16", "18.13"]
     steps:
       - uses: AbsaOSS/k3d-action@v2
         name: "Create fluvio k3d Cluster"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - staging
       - trying
+      - try-older-version-of-node-18
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         os: [macos-latest]
         rust: [stable]
-        node: [ '14', '16', '18' ]
+        node: [ '14', '16', '18.12' ]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.rust }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os: [macos-latest]
         rust: [stable]
-        node: ["14", "16", "18.14.0"]
+        node: ["14", "16", "18.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.rust }}
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        node: ["14", "16", "18.14.0"]
+        node: ["14", "16", "18.13"]
     steps:
       - uses: AbsaOSS/k3d-action@v2
         name: "Create fluvio k3d Cluster"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os: [macos-latest]
         rust: [stable]
-        node: ["14", "16", "18.6"]
+        node: ["14", "16", "18.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.rust }}
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        node: ["14", "16", "18.6"]
+        node: ["14", "16", "18.12"]
     steps:
       - uses: AbsaOSS/k3d-action@v2
         name: "Create fluvio k3d Cluster"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - staging
       - trying
-      - try-older-version-of-node-18
   pull_request:
     branches: [master]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os: [macos-latest]
         rust: [stable]
-        node: ["14", "16", "18.12"]
+        node: ["14", "16", "18.14.2"]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.rust }}
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        node: ["14", "16", "18.12"]
+        node: ["14", "16", "18.14.2"]
     steps:
       - uses: AbsaOSS/k3d-action@v2
         name: "Create fluvio k3d Cluster"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os: [macos-latest]
         rust: [stable]
-        node: ["14", "16", "18.13"]
+        node: ["14", "16", "18.14.0"]
     steps:
       - uses: actions/checkout@v3
       - name: Install ${{ matrix.rust }}
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable]
-        node: ["14", "16", "18.13"]
+        node: ["14", "16", "18.14.0"]
     steps:
       - uses: AbsaOSS/k3d-action@v2
         name: "Create fluvio k3d Cluster"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2674,9 +2674,9 @@
             "dev": true
         },
         "node_modules/json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
@@ -5995,9 +5995,9 @@
             "dev": true
         },
         "json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true
         },
         "jsonc-parser": {


### PR DESCRIPTION
This is done in order to unblock CI. We need to research why on node>=18.14 we get segmention errors