### PR TITLE
chore: ci fix latest-dev-fluvio

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Install fluvio
         run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh | bash
+          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | bash
           echo "${HOME}/.fluvio/bin" >> $GITHUB_PATH
 
       - uses: actions-rs/install@v0.1

--- a/.github/workflows/latest-dev-fluvio.yaml
+++ b/.github/workflows/latest-dev-fluvio.yaml
@@ -67,11 +67,12 @@ jobs:
 
       - name: Install fluvio
         run: |
-          curl -fsS https://hub.infinyon.cloud/install/install.sh | bash
+          curl -fsS https://hub.infinyon.cloud/install/install.sh?ctx=ci | bash
+          echo "${HOME}/.fvm/bin" >> $GITHUB_PATH
           echo "${HOME}/.fluvio/bin" >> $GITHUB_PATH
       - name: Update fluvio client to development and start the local cluster.
         run: |
-          fluvio update --develop
+          fvm install latest
           fluvio cluster start --rust-log debug --local
 
       - name: Sleep 10 to ensure the fluvio cluster is ready

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -14,12 +14,7 @@ Follow the instructions in the links above to install the development tools.
 ## Building and Testing
 
 ### Developing the Native Module
-
-Running `make build` will build the `./src/**/*.{ts,rs}` files, generating a `dist/` folder for the JavaScript files and a native module at the location `./dist/<platform>/index.node`.
-
-```
-make build
-```
+fluvio update --develop
 
 When developing, you need to set the environment variable, `FLUVIO_DEV` to a non zero value.
 
@@ -43,4 +38,6 @@ However, make sure you have your `FLUVIO_DEV` environment variable set before ru
 
 ### Publishing `@fluvio/client`
 
-Run the [Publish GitHub workflow](https://github.com/infinyon/fluvio-client-node/actions/workflows/publish.yml).
+Run the [Publish GitHub workflow](https://github.com/infinyon/fluvio-client-node/actions/workflows/publish.yml) by tagging
+the repository with the a version tag "vX.Y.Z".
+


### PR DESCRIPTION
cloud: use ci tag
latest-dev-fluvio: use fvm to get latest
docs: add dev notes, closes #307
